### PR TITLE
feature:profileページのtable作成

### DIFF
--- a/src/app/(pages)/profile/page.tsx
+++ b/src/app/(pages)/profile/page.tsx
@@ -6,25 +6,72 @@ interface TestResult {
   year: string;
   teacherScore: number;
   studentScore: number;
+  memo: string;
 }
 
 export default function ProfilePage() {
   // テストデータ - 講師と生徒両方の点数を含む
   const testResults: TestResult[] = [
-    { date: "2024/08/01", year: "2018", teacherScore: 80, studentScore: 75 },
-    { date: "2024/07/01", year: "2017", teacherScore: 70, studentScore: 65 },
-    { date: "2024/06/01", year: "2016", teacherScore: 85, studentScore: 80 },
-    { date: "2024/05/01", year: "2015", teacherScore: 90, studentScore: 85 },
-    { date: "2024/04/01", year: "2014", teacherScore: 80, studentScore: 75 },
-    { date: "2024/03/01", year: "2013", teacherScore: 60, studentScore: 55 },
-    { date: "2024/02/01", year: "2012", teacherScore: 40, studentScore: 45 },
-    { date: "2024/01/01", year: "2011", teacherScore: 10, studentScore: 15 },
+    {
+      date: "2024/08/01",
+      year: "2018",
+      teacherScore: 80,
+      studentScore: 75,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
+    {
+      date: "2024/07/01",
+      year: "2017",
+      teacherScore: 70,
+      studentScore: 65,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
+    {
+      date: "2024/06/01",
+      year: "2016",
+      teacherScore: 85,
+      studentScore: 80,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
+    {
+      date: "2024/05/01",
+      year: "2015",
+      teacherScore: 90,
+      studentScore: 85,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
+    {
+      date: "2024/04/01",
+      year: "2014",
+      teacherScore: 80,
+      studentScore: 75,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
+    {
+      date: "2024/03/01",
+      year: "2013",
+      teacherScore: 60,
+      studentScore: 55,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
+    {
+      date: "2024/02/01",
+      year: "2012",
+      teacherScore: 40,
+      studentScore: 45,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
+    {
+      date: "2024/01/01",
+      year: "2011",
+      teacherScore: 10,
+      studentScore: 15,
+      memo: "この日は調子が悪かったのでしょうがなかった。",
+    },
   ];
   // 複数の目標点を配列で指定
-  // 目標点数と最低ライン
-  const referenceScoreTarget = 84;
-  const referenceScoreLowest = 70;
   const profileInfo = {
+    userName: "数1Aは32点だけど千葉大に受かりたい人",
     targetUniversity: [
       "千葉大学-理学部-地球科学科",
       "明治大学-農学部-農学科",
@@ -33,37 +80,35 @@ export default function ProfilePage() {
     comment:
       "サッカー部の活動時間が長く、勉強時間が1日2時間程度しか取れていないため、内職をして時間を確保したり、過去問をもとに本当に必要なものを優先したりと工夫して勉強しています。",
   };
-  const longDescription =
-    "英語は1月から英語長文ポラリス1の文を例文としてスラスラ言えるレベルをテーマに30分/日音読をしたことで伸びた気がします。";
-
   return (
     <>
       <TestResultCard
-        userName="高三10月に文転したけど横国に行くぞ！"
+        profileInfo={profileInfo}
         subject="英語"
         testResults={testResults}
-        referenceScoreTarget={referenceScoreTarget}
-        referenceScoreLowest={referenceScoreLowest}
-        profileInfo={profileInfo}
-        description={longDescription}
+        referenceScoreTarget={84}
+        referenceScoreLowest={70}
+        description={
+          "英語は1月から英語長文ポラリス1の文を例文としてスラスラ言えるレベルをテーマに30分/日音読をしたことで伸びた気がします。"
+        }
       />
       <TestResultCard
-        userName="数1Aは32点だけど千葉大に受かりたい人"
+        profileInfo={profileInfo}
         subject="数1A"
         testResults={testResults}
-        referenceScoreTarget={referenceScoreTarget}
-        referenceScoreLowest={referenceScoreLowest}
-        profileInfo={profileInfo}
-        description={longDescription}
+        referenceScoreTarget={75}
+        referenceScoreLowest={60}
+        description={"数1Aは基礎問を2周回したら70点台に乗りました。"}
       />
       <TestResultCard
-        userName="kanau888"
+        profileInfo={profileInfo}
         subject="数2B"
         testResults={testResults}
-        referenceScoreTarget={referenceScoreTarget}
-        referenceScoreLowest={referenceScoreLowest}
-        profileInfo={profileInfo}
-        description={longDescription}
+        referenceScoreTarget={75}
+        referenceScoreLowest={60}
+        description={
+          "数2Bは基礎問を3周回したら70点台に乗りました。たくさん演習を積むことが大事だと思います。"
+        }
       />
     </>
   );

--- a/src/app/components/general/TestResultCard/index.tsx
+++ b/src/app/components/general/TestResultCard/index.tsx
@@ -7,6 +7,7 @@ import {
   MessageCircleMore,
   ListFilter,
   BookmarkIcon,
+  ArrowRightToLine,
 } from "lucide-react";
 import {
   Line,
@@ -27,20 +28,23 @@ interface TestResult {
   year: string;
   teacherScore: number;
   studentScore: number;
+  memo: string;
 }
 
 interface TestResultCardProps {
-  userName: string;
   testResults: TestResult[];
   subject: string;
   referenceScoreTarget?: number;
   referenceScoreLowest?: number;
   description?: string;
-  profileInfo: { targetUniversity: string[]; comment: string };
+  profileInfo: {
+    userName: string;
+    targetUniversity: string[];
+    comment: string;
+  };
 }
 
 export default function TestResultCard({
-  userName,
   subject,
   testResults,
   referenceScoreTarget = 80,
@@ -113,7 +117,10 @@ export default function TestResultCard({
             className="rounded-full object-cover"
           />
         </div>
-        <div className="text-xs font-bold">{userName}</div>
+        <div className="text-xs flex">
+          <p className="font-bold">{profileInfo.userName}</p>
+          <p>　{subject}</p>
+        </div>
       </div>
 
       {/* グラフ部分 */}
@@ -197,7 +204,7 @@ export default function TestResultCard({
       {/* アクションボタン */}
       <div className="flex items-center px-2">
         <button
-          className="p-2 text-gray-500"
+          className="p-2"
           onClick={() => setShowProfileInfo(!showProfileInfo)}
           aria-expanded={showProfileInfo}
         >
@@ -208,7 +215,7 @@ export default function TestResultCard({
           />
         </button>
         <button
-          className="p-2 text-gray-500"
+          className="p-2"
           onClick={() => setShowFullDescription(!showFullDescription)}
           aria-expanded={showFullDescription}
         >
@@ -219,7 +226,7 @@ export default function TestResultCard({
           />
         </button>
         <button
-          className="p-2 text-gray-500"
+          className="p-2 "
           onClick={() => setShowTable(!showTable)}
           aria-expanded={showTable}
         >
@@ -229,7 +236,10 @@ export default function TestResultCard({
             }`}
           />
         </button>
-        <button className="p-2 ml-auto text-gray-500">
+        <button
+          onClick={() => alert("今後実装予定の機能です。")}
+          className="p-2 ml-auto"
+        >
           <BookmarkIcon className="w-6 h-6" />
         </button>
       </div>
@@ -299,24 +309,32 @@ export default function TestResultCard({
         }}
       >
         <div ref={tableRef}>
-          <table className="w-full border-collapse">
+          <table className="w-full border-collapse text-sm text-gray-600">
             <thead>
-              <tr className="text-gray-600 border-b">
-                <th className="px-4 py-3 text-left">
-                  解いた日 <span className="inline-block ml-1">↓</span>
-                </th>
-                <th className="px-4 py-3 text-left">年度</th>
-                <th className="px-4 py-3 text-left">点数</th>
-                <th className="w-10 px-4 py-3 text-center">✕</th>
+              <tr className="border-b border-gray-200">
+                <th className="p-2 w-12">解いた日</th>
+                <th className="p-2 w-12">点数</th>
+                <th className="p-2 w-12">年度</th>
+                <th className="p-2">メモ</th>
+                <th className="p-2 w-12">詳細</th>
               </tr>
             </thead>
             <tbody>
               {testResults.map((result: TestResult, index: number) => (
-                <tr key={index} className="border-b">
-                  <td className="px-4 py-3">{result.date}</td>
-                  <td className="px-4 py-3">{result.year}</td>
-                  <td className="px-4 py-3">{result.teacherScore}</td>
-                  <td className="px-4 py-3 text-center text-gray-400">✕</td>
+                <tr key={index} className="border-b border-gray-200">
+                  <td className="p-2 text-center">{result.date}</td>
+                  <td className="p-2 text-center font-bold">
+                    {result.teacherScore}
+                  </td>
+                  <td className="p-2 text-center">{result.year}</td>
+                  <td className="p-2 text-center truncate max-w-[150px]">
+                    {result.memo}
+                  </td>
+                  <td className="p-2 text-gray-400">
+                    <button onClick={() => alert("詳細ボタンが押されました")}>
+                      <ArrowRightToLine size={16} className="ml-2" />
+                    </button>
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
**行ったこと**

- profileページのCardコンポーネント内で使用するTableを作成。
- mobileとPCに対応するため、tailwindCSSのtrancateを使用し、テキストの文字数を対象領域のwidthに合わせて制御し...で表現した。